### PR TITLE
[sentinel-fix] [sentinel] cli-list still failing (2x): mcper list command does not exist

### DIFF
--- a/cmd/mcper/list.go
+++ b/cmd/mcper/list.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List plugins configured in this project",
+	Long: `List all MCP plugins configured in the current project's .mcper/start.sh.
+
+Examples:
+  mcper list          List configured plugins
+  mcper list --json   Output as JSON`,
+	RunE: runPluginList,
+}
+
+func init() {
+	listCmd.Flags().BoolVar(&pluginListJSON, "json", false, "Output as JSON")
+}

--- a/cmd/mcper/main.go
+++ b/cmd/mcper/main.go
@@ -44,6 +44,7 @@ func init() {
 	rootCmd.AddCommand(cacheCmd)
 	rootCmd.AddCommand(enableCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(pluginCmd)
 	rootCmd.AddCommand(registryCmd)
 


### PR DESCRIPTION
Closes #3

Auto-generated by [mcper-sentinel-fixer](https://github.com/joshcarp/mcper-sentinel).

**Summary**: Added top-level `mcper list` command (cmd/mcper/list.go) that delegates to the existing runPluginList function, fixing the 'unknown command list' error.

**HEAD**: `4fe1d76 feat(cli): add top-level `mcper list` command`

Run the feature check after merge:
```
python3 runner/sentinel.py --feature <feature-id>
```
