### PR TITLE
[sentinel-fix] [sentinel] cli-version-embedded broken: embedded ldflag value not appearing in o

### DIFF
--- a/cmd/mcper/version.go
+++ b/cmd/mcper/version.go
@@ -7,6 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is set at build time via -ldflags "-X main.version=..."
+var version string
+
+func init() {
+	if version != "" {
+		mcper.Version = version
+	}
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",


### PR DESCRIPTION
Closes #6

Auto-generated by [mcper-sentinel-fixer](https://github.com/joshcarp/mcper-sentinel).

**Summary**: Added `var version string` to the main package in cmd/mcper/version.go and an init() that copies it to mcper.Version when non-empty. This makes `-ldflags "-X main.version=v0.0.0-test"` correctly override the displayed version, matching the sentinel test expectation.

**HEAD**: `541b952 fix(cli): wire main.version ldflag to mcper.Version`

Run the feature check after merge:
```
python3 runner/sentinel.py --feature <feature-id>
```
