### PR TITLE
[sentinel-fix] [sentinel] cli-readme-commands-match broken: claude exited -9

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Once `.mcper/start.sh` is committed, anyone who clones the repo will have mcper 
 | currency | Currency conversion - real-time rates | (none) |
 
 ```bash
-# List all available plugins
-mcper list
+# List all available plugins in the registry
+mcper registry list
 ```
 
 ## Commands
@@ -50,7 +50,8 @@ mcper list
 ```bash
 mcper init              # Initialize .mcper/start.sh
 mcper add <plugin>      # Add a plugin
-mcper list              # List available plugins
+mcper list              # List plugins configured in this project
+mcper registry list     # List available plugins in the registry
 mcper enable --claude   # Add to .mcp.json for Claude Code
 mcper serve             # Run MCP server (called by start.sh)
 mcper update            # Update mcper to latest version


### PR DESCRIPTION
Closes #9

Auto-generated by [mcper-sentinel-fixer](https://github.com/joshcarp/mcper-sentinel).

**Summary**: Fixed README mismatch: `mcper list` was documented as 'List available plugins' but actually lists configured project plugins. Corrected the Available Plugins section to use `mcper registry list`, and added `mcper registry list` as a separate entry in the Commands section with accurate descriptions for both commands.

**HEAD**: `0eac165 docs(readme): fix mcper list description to match actual CLI behavior`

Run the feature check after merge:
```
python3 runner/sentinel.py --feature <feature-id>
```
