### PR TITLE
[sentinel-fix] [sentinel] cli-edge-cases broken: claude exited 143

### DIFF
--- a/cmd/mcper/registry.go
+++ b/cmd/mcper/registry.go
@@ -57,7 +57,7 @@ func init() {
 func fetchPluginsManifest() (*PluginsManifest, error) {
 	pluginsURL := mcper.GCSBaseURL + "/plugins.json"
 
-	resp, err := http.Get(pluginsURL)
+	resp, err := httpClient.Get(pluginsURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch plugins: %w", err)
 	}

--- a/cmd/mcper/update.go
+++ b/cmd/mcper/update.go
@@ -9,12 +9,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/joshcarp/mcper/pkg/mcper"
 	"github.com/spf13/cobra"
 )
 
 const githubAPIURL = "https://api.github.com/repos/joshcarp/mcper/releases/latest"
+
+var httpClient = &http.Client{Timeout: 5 * time.Second}
 
 // GitHubRelease represents the GitHub releases API response
 type GitHubRelease struct {
@@ -68,7 +71,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func fetchLatestVersion() (string, error) {
-	resp, err := http.Get(githubAPIURL)
+	resp, err := httpClient.Get(githubAPIURL)
 	if err != nil {
 		return "", err
 	}
@@ -130,7 +133,7 @@ func downloadAndInstall(version string) error {
 	downloadURL := fmt.Sprintf("%s/v%s/%s", mcper.GCSBaseURL, version, assetName)
 	fmt.Printf("Downloading mcper v%s for %s...\n", version, platform)
 
-	resp, err := http.Get(downloadURL)
+	resp, err := httpClient.Get(downloadURL)
 	if err != nil {
 		return fmt.Errorf("failed to download: %w", err)
 	}


### PR DESCRIPTION
Closes #17

Auto-generated by [mcper-sentinel-fixer](https://github.com/joshcarp/mcper-sentinel).

**Summary**: Added a 5-second timeout to the shared HTTP client used by fetchLatestVersion (update.go) and fetchPluginsManifest (registry.go). Without a timeout, these http.Get calls block indefinitely in offline/sandboxed environments, causing the process to be killed with SIGTERM (exit code 143) by the sentinel test runner.

**HEAD**: `78586e4 fix(cli): add 5s timeout to HTTP clients to prevent hanging on network unavailability`

Run the feature check after merge:
```
python3 runner/sentinel.py --feature <feature-id>
```
